### PR TITLE
(doc) add required first argument to "init" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Make sure you have the plugins files and CoreMotion and CoreLocation framework a
 Init with callback function
 
 ```
-window.PedometerCordova.init(function(data)
+window.PedometerCordova.init('', function(data)
 {
     console.log(JSON.stringify(data));
 });


### PR DESCRIPTION
As defined in the "www/PedometerCordova.js" file, the init method expect 2 arguments. The first is a string, the second is a callback. I have updated the code example in the README.md to include an empty string as the first argument. Without that, the callback can't ever be executed.
